### PR TITLE
feat: ブログのContents Collectionを定義

### DIFF
--- a/src/components/home/MemberContentCard.astro
+++ b/src/components/home/MemberContentCard.astro
@@ -1,0 +1,26 @@
+---
+import { getEntry } from 'astro:content';
+import MemberCard from './MemberCard.astro';
+import type { ComponentProps } from 'astro/types';
+
+interface Props {
+  id: string;
+  description: string;
+  class?: ComponentProps<typeof MemberCard>['class'];
+}
+
+const { id, description, class: classes } = Astro.props;
+const member = await getEntry('members', id);
+
+if (!member) throw new Error(`No such member: ${id}`);
+---
+
+<MemberCard
+  icon={member.data.icon}
+  name={member.data.name}
+  description={description}
+  github={member.data.github}
+  twitter={member.data.twitter}
+  website={member.data.website}
+  class={classes}
+/>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,27 @@
+import { defineCollection, reference, z } from 'astro:content';
+import { file, glob } from 'astro/loaders';
+
+const blog = defineCollection({
+  loader: glob({ pattern: '*.md', base: 'src/contents/blog' }),
+  schema: z.object({
+    title: z.string(),
+    cover: z.string(),
+    author: reference('member'),
+    createdAt: z.date(),
+    tags: z.string().array(),
+  }),
+});
+
+const members = defineCollection({
+  loader: file('src/contents/members/members.yaml'),
+  schema: z.object({
+    id: z.string(),
+    name: z.string(),
+    icon: z.string(),
+    github: z.string().optional(),
+    twitter: z.string().optional(),
+    website: z.string().optional(),
+  }),
+});
+
+export const collections = { blog, members };

--- a/src/contents/members/members.yaml
+++ b/src/contents/members/members.yaml
@@ -1,0 +1,31 @@
+- id: laminne
+  name: laminne
+  icon: https://github.com/laminne.png
+  github: laminne
+  twitter: laminne33
+  website: laminne33569.net
+
+- id: namekujitoiisyoubusiteru
+  name: namekujitoiisyoubusiteru
+  icon: https://github.com/kiharu3112.png
+  github: kiharu3112
+  twitter: kijiharu_mct
+
+- id: tufusa
+  name: tufusa
+  icon: https://github.com/tufusa.png
+  github: tufusa
+  twitter: louptung
+  website: tufusa.net
+
+- id: Teselapfer
+  name: Teselapfer
+  icon: https://github.com/teselapfer.png
+  github: Teselapfer
+
+- id: speak-mentaiko
+  name: speak-mentaiko
+  icon: https://github.com/speak-mentaiko.png
+  github: speak-mentaiko
+  twitter: speak_mentaiko
+  website: mentaiko.net

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,8 +3,8 @@ import Layout from '@layouts/Layout.astro';
 import Section from '@components/home/Section.astro';
 import Table from '@components/home/Table.astro';
 import Banner from '@components/home/Banner.astro';
-import MemberCard from '@components/home/MemberCard.astro';
 import WorkCard from '@components/home/WorkCard.astro';
+import MemberContentCard from '@components/home/MemberContentCard.astro';
 ---
 
 <Layout>
@@ -57,28 +57,11 @@ import WorkCard from '@components/home/WorkCard.astro';
   </Section>
   <Section title="Members" details="メンバー紹介">
     <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-      <MemberCard
-        icon="https://github.com/laminne.png"
-        name="Cotori Yamamoto"
-        description="国人領主"
-        github="laminne"
-        twitter="laminne33"
-        website="laminne33569.net"
-      />
-      <MemberCard
-        icon="https://github.com/kiharu3112.png"
-        name="namekujitoiisyoubusiteru"
-        description="domestic animals"
-        github="kiharu3112"
-        twitter="kijiharu_mct"
-      />
-      <MemberCard
-        icon="https://github.com/tufusa.png"
-        name="tufusa"
+      <MemberContentCard id="laminne" description="国人領主" />
+      <MemberContentCard id="namekujitoiisyoubusiteru" description="domestic animals" />
+      <MemberContentCard
+        id="tufusa"
         description="型パズル士4級"
-        github="tufusa"
-        twitter="louptung"
-        website="tufusa.net"
         class={{
           container: `transition-all duration-1000 hover:bg-[#121222]
             hover:text-white hover:[&_img]:rounded-[100%]
@@ -88,20 +71,8 @@ import WorkCard from '@components/home/WorkCard.astro';
           icon: 'transition-all duration-1000',
         }}
       />
-      <MemberCard
-        icon="https://github.com/teselapfer.png"
-        name="Teselapfer"
-        description="マンホールから抜け出せません"
-        github="Teselapfer"
-      />
-      <MemberCard
-        icon="https://github.com/speak-mentaiko.png"
-        name="speak-mentaiko"
-        description="普通自動二輪"
-        github="speak-mentaiko"
-        twitter="speak_mentaiko"
-        website="mentaiko.net"
-      />
+      <MemberContentCard id="Teselapfer" description="マンホールから抜け出せません" />
+      <MemberContentCard id="speak-mentaiko" description="普通自動二輪" />
     </div>
   </Section>
   <Section title="Works" details="過去の制作物">


### PR DESCRIPTION
close #152 

- Contents Collection `blog`と`members`を定義した
- `members`コレクションから情報を取得する`MemberContentCard`を作成した(使用例を兼ねる)